### PR TITLE
Add a conda environment file for convenient installation.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,12 @@
+name: spacy-tutorial
+channels:
+  - conda-forge
+  - etetoolkit
+  - defaults
+dependencies:
+  - ete3
+  - ete_toolchain
+  - pandas
+  - seaborn
+  - scikit-learn
+  - spacy


### PR DESCRIPTION
This might make installation easier for conda users. It also avoids making any changes to existing configuration by creating a separate conda environment named `spacy-tutorial`.

Usage:

```bash
conda env create -f environment.yml

# On OSX / Linux:
source activate spacy-tutorial
# On Windows:
activate spacy-tutorial
```

In tutorials, most unexpected problems I've seen can be solved by updating conda:

```bash
conda update conda
```